### PR TITLE
Fix constraints in groups resize bug

### DIFF
--- a/code.js
+++ b/code.js
@@ -40,7 +40,7 @@ figma.ui.onmessage = msg => {
             frame.x = selection.reduce((prev, curr) => prev.x < curr.x ? prev : curr).x;
             frame.y = selection.reduce((prev, curr) => prev.y < curr.y ? prev : curr).y;
             let baseWidth = getTotalWidth(selection);
-            frame.resize(baseWidth, frame.height);
+            frame.resizeWithoutConstraints(baseWidth, frame.height);
             selection.forEach(n => frame.appendChild(n));
             applyLayout(frame, rowGap, colGap);
         }
@@ -83,7 +83,7 @@ function applyLayout(frame, rowGap, colGap) {
         // new y is total height of all placed children, plus a gap
         y = getTotalHeight(placedChildren) + rowGap;
     }
-    frame.resize(frame.width, getTotalHeight(placedChildren));
+    frame.resizeWithoutConstraints(frame.width, getTotalHeight(placedChildren));
     figma.currentPage.selection = [frame];
 }
 // Utils

--- a/code.ts
+++ b/code.ts
@@ -51,7 +51,7 @@ figma.ui.onmessage = msg => {
       frame.y = selection.reduce((prev, curr) => prev.y < curr.y ? prev : curr).y
 
       let baseWidth = getTotalWidth(selection)
-      frame.resize(baseWidth, frame.height)
+      frame.resizeWithoutConstraints(baseWidth, frame.height)
 
       selection.forEach(n => frame.appendChild(n))
 
@@ -117,7 +117,7 @@ function applyLayout(frame, rowGap, colGap) {
     y = getTotalHeight(placedChildren) + rowGap
   }
 
-  frame.resize(frame.width, getTotalHeight(placedChildren))
+  frame.resizeWithoutConstraints(frame.width, getTotalHeight(placedChildren))
 
   figma.currentPage.selection = [frame]
 }


### PR DESCRIPTION
This fixes an issue with group nodes as children of the frame. If any
node in the group had constraints, they would be taken into account when
the parent frame is resized, stretching the node.

fixes #1 